### PR TITLE
Fixed bug where `-v` wouldn't work as expected

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,7 +16,7 @@ var options = {
 }
 // -v is a shorthand for --version
 var shorthands = {
-  "v": "version"
+  "v": "--version"
 }
 var parsed = nopt(options, shorthands);
 


### PR DESCRIPTION
`-v` was returning the help instead of the version number, as it was shorthanded to `version` instead of `--version`.