### PR TITLE
Fixes for messages

### DIFF
--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -55,7 +55,7 @@ module.exports = function(args, options, callback, ee) {
       framework = answers.framework || options.framework;
       template = answers.template || options.template || null;
       projectFolder = path.join(process.cwd(), projectName);
-      messages = util.messages(projectName);
+      messages = util.messages(projectName,framework);
 
       cb();
     });

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -53,9 +53,9 @@ module.exports = function(args, options, callback, ee) {
       // The variables we need either came from the prompts, or the console arguments
       projectName = answers.directory || options.directory;
       framework = answers.framework || options.framework;
-      template = answers.template || options.template || null;
+      template = answers.template || options.template || 'unspecified';
       projectFolder = path.join(process.cwd(), projectName);
-	messages = util.messages(projectName,framework,template);
+      messages = util.messages(projectName,framework,template);
 
       cb();
     });
@@ -74,6 +74,11 @@ module.exports = function(args, options, callback, ee) {
     process.stdout.write(messages.downloadingTemplate);
 
     // [TODO] Change to spawn and check for errors on stderr
+    if (repositories[framework] === undefined) {
+	console.log("error!".red + "\nFramework " + framework.cyan + " unknown.");
+	process.exit(1);
+    }
+
     exec(cmd, function(err) {
       if (err instanceof Error) {
         console.log(messages.gitCloneError);

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -55,7 +55,7 @@ module.exports = function(args, options, callback, ee) {
       framework = answers.framework || options.framework;
       template = answers.template || options.template || null;
       projectFolder = path.join(process.cwd(), projectName);
-      messages = util.messages(projectName,framework);
+	messages = util.messages(projectName,framework,template);
 
       cb();
     });

--- a/lib/util/messages.js
+++ b/lib/util/messages.js
@@ -10,7 +10,7 @@ module.exports = function(projectName,messageFramework,messageTemplate) {
     ],
     folderExists: "\nThere's already a folder named " + projectName.cyan + " here. Please use a different name or delete that folder.\n",
     downloadingTemplate: "\nDownloading the project template...".cyan,
-    gitCloneError: "There was an issue running " + "git clone ".cyan + "to download the framework " + "Foundation for ".cyan + messageFramework.cyan + " and template " + messageTemplate.cyan+".\nMake sure your computer's Git is configured properly and then try again.",
+    gitCloneError: "There was an issue running " + "git clone ".cyan + "to download the framework " + "Foundation for ".cyan + messageFramework.cyan + " and template " + messageTemplate.cyan +".\nMake sure your computer's Git is configured properly and then try again.",
     installingDependencies: "\nDone downloading!".green + "\n\nInstalling dependencies...".cyan + "\n",
     gitCloneSuccess: " \u2713 New project folder created.".green,
     installSuccess: "\nYou're all set!\n".cyan,

--- a/lib/util/messages.js
+++ b/lib/util/messages.js
@@ -1,6 +1,6 @@
 var colors = require('colors');
 
-module.exports = function(projectName) {
+module.exports = function(projectName,messageFramework) {
   return {
     helloYeti: [
       'Thanks for using ZURB Foundation for %s!',
@@ -10,7 +10,7 @@ module.exports = function(projectName) {
     ],
     folderExists: "\nThere's already a folder named " + projectName.cyan + " here. Please use a different name or delete that folder.\n",
     downloadingTemplate: "\nDownloading the project template...".cyan,
-    gitCloneError: "There was an issue running " + "git clone ".cyan + "to download the Foundation for Apps template.\nMake sure your computer's Git is configured properly and then try again.",
+    gitCloneError: "There was an issue running " + "git clone ".cyan + "to download the " + "Foundation for ".cyan + messageFramework.cyan + " template.\nMake sure your computer's Git is configured properly and then try again.",
     installingDependencies: "\nDone downloading!".green + "\n\nInstalling dependencies...".cyan + "\n",
     gitCloneSuccess: " \u2713 New project folder created.".green,
     installSuccess: "\nYou're all set!\n".cyan,

--- a/lib/util/messages.js
+++ b/lib/util/messages.js
@@ -1,6 +1,6 @@
 var colors = require('colors');
 
-module.exports = function(projectName,messageFramework) {
+module.exports = function(projectName,messageFramework,messageTemplate) {
   return {
     helloYeti: [
       'Thanks for using ZURB Foundation for %s!',
@@ -10,7 +10,7 @@ module.exports = function(projectName,messageFramework) {
     ],
     folderExists: "\nThere's already a folder named " + projectName.cyan + " here. Please use a different name or delete that folder.\n",
     downloadingTemplate: "\nDownloading the project template...".cyan,
-    gitCloneError: "There was an issue running " + "git clone ".cyan + "to download the " + "Foundation for ".cyan + messageFramework.cyan + " template.\nMake sure your computer's Git is configured properly and then try again.",
+    gitCloneError: "There was an issue running " + "git clone ".cyan + "to download the framework " + "Foundation for ".cyan + messageFramework.cyan + " and template " + messageTemplate.cyan+".\nMake sure your computer's Git is configured properly and then try again.",
     installingDependencies: "\nDone downloading!".green + "\n\nInstalling dependencies...".cyan + "\n",
     gitCloneSuccess: " \u2713 New project folder created.".green,
     installSuccess: "\nYou're all set!\n".cyan,


### PR DESCRIPTION
- [x] The `gitCloneError` message will now properly refer to the request framework type.
- [x] The `gitCloneError` message will now properly refer to the request template type.
- [x] Catch bad framework choice.