### PR TITLE
test for user operating platform

### DIFF
--- a/lib/commands/watch.js
+++ b/lib/commands/watch.js
@@ -1,13 +1,26 @@
 var fs = require('fs');
 var npm = require('npm');
 var path = require('path');
+var os = require('os');
+//
+var platform = os.platform();
+var platformResponse = function() {
+  var r = "";
+  if (["darwin","freebsd","linux","openbsd","sunos"].indexOf(platform) > -1)
+    r = "pwd";
+  if (["win32"].indexOf(platform) > -1)
+    r = "chdir";
+  if (r === "")
+    r = "the appropriate command";
+  return "\nYou don't appear to be in a Foundation project folder.\n\nUse " + r.cyan + " to see what folder you're in.\n";
+}
 
 module.exports = function(args, options) {
   // Check if the user is inside a project folder, by looking for a package.json
-  if (!fs.existsSync(path.join(process.cwd(), 'package.json'))) {
-    console.log("\nYou don't appear to be in a Foundation project folder.\n\nUse " + "pwd".cyan + " (or " + "chdir".cyan + " on Windows) to see what folder you're in.\n");
-    process.exit(0);
-  }
+  if (!fs.existsSync(path.join(process.cwd(), 'package.json')))
+    console.log(platformResponse());
+
+  process.exit(0);
 
   npm.load({ prefix: process.cwd(), loaded: false }, function(err) {
     npm.commands.start.apply(this, []);


### PR DESCRIPTION
Nothing more than the title. If the machine's platform is either of these -- "darwin","freebsd","linux","openbsd","sunos" -- then the user is asked to use the `pwd` command.

If the platform is type "win32", they are asked to use `chdir`.

Fallback is "the appropriate command."

__EDIT__: Perhaps someone with a windows box could test this?