### PR TITLE
Updated package.json to lock colors.js to use version 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "async": "^3.2.1",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "inquirer": "^8.1.5",
     "is-root": "^2.1.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
Please consider doing this after the news today about colors.js

[https://www.theverge.com/2022/1/9/22874949/developer-corrupts-open-source-libraries-projects-affected](url)

Can't use the Foundation CLI at all without the LIBERTY LIBERTY LIBERTY corruption message.